### PR TITLE
Add `scope!` macro

### DIFF
--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -5,3 +5,11 @@ fn smoke() {
     coz::begin!("foo");
     coz::end!("foo");
 }
+
+#[test]
+fn smoke_scoped() {
+    coz::scope!("scope");
+    let mut x = 1u32;
+    x = x + 1;
+    assert!(x == 2);
+}


### PR DESCRIPTION
Similar to [flame](https://docs.rs/flame)'s `flame_guard`, this gives us the possibility to mark a scope so that it gets a begin and end counter *and* we can be sure that the end counter is incremented even on early exit.